### PR TITLE
Use -L instead of -I in LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ $(if $(MPFR_PREFIX),-I$(MPFR_PREFIX)/include) \
 -I$(CAML_PREFIX) -I$(CAMLIDL_PREFIX)
 
 LDFLAGS += \
-$(if $(GMP_PREFIX),-I$(GMP_PREFIX)/lib) \
-$(if $(MPFR_PREFIX),-I$(MPFR_PREFIX)/lib) \
+$(if $(GMP_PREFIX),-L$(GMP_PREFIX)/lib) \
+$(if $(MPFR_PREFIX),-L$(MPFR_PREFIX)/lib) \
 -L$(CAML_PREFIX) -L$(CAML_PREFIX)/stublibs -L$(CAMLIDL_PREFIX) \
 $(LIBS)
 


### PR DESCRIPTION
It seems that some of LDFLAGS were mistakenly changed from `-L` to `-I` by https://github.com/nberth/mlgmpidl/commit/9b5e2d6faa56e91cfe8fb9f5c115f039266a60b2.
