### PR TITLE
Disable profiling for ocaml version > 4.08.0

### DIFF
--- a/configure
+++ b/configure
@@ -370,7 +370,7 @@ if test $enable_prof -eq 1
 then
     echo -n "checking whether to enable profiling: "
     case "${overs}" in
-	4.08.[1-9]*|4.09.*|4.[1-9]*|5*)
+	4.08.[1-9]*|4.09.*|4.[1-9]*|[5-9]*|[1-9][0-9]*)
 	    echo "only available up to OCaml 4.08.0 (<= ${overs})";
 	    enable_prof=0;;
 	*)

--- a/configure
+++ b/configure
@@ -370,7 +370,7 @@ if test $enable_prof -eq 1
 then
     echo -n "checking whether to enable profiling: "
     case "${overs}" in
-	4.08.[1-9]*|4.09.*|4.[1-9]*|5.[0-9]*)
+	4.08.[1-9]*|4.09.*|4.[1-9]*|5*)
 	    echo "only available up to OCaml 4.08.0 (<= ${overs})";
 	    enable_prof=0;;
 	*)

--- a/configure
+++ b/configure
@@ -370,7 +370,7 @@ if test $enable_prof -eq 1
 then
     echo -n "checking whether to enable profiling: "
     case "${overs}" in
-	4.08.[1-9]*|4.09.*|4.[1-9]*)
+	4.08.[1-9]*|4.09.*|4.[1-9]*|5.[0-9]*)
 	    echo "only available up to OCaml 4.08.0 (<= ${overs})";
 	    enable_prof=0;;
 	*)

--- a/opam/opam
+++ b/opam/opam
@@ -18,6 +18,7 @@ depends: [
   "conf-gmp"
   "conf-mpfr"
   "conf-perl" {build}
+  "bigarray-compat"
 ]
 conflicts: [
   "mlgmp"

--- a/opam/opam
+++ b/opam/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/nberth/mlgmpidl/issues"
 homepage: "https://www.inrialpes.fr/pop-art/people/bjeannet/mlxxxidl-forge/mlgmpidl/"
 license: "LGPL-2.1 with static linking exception"
 build: [
-  ["sh" "./configure" "-disable-profiling" {ocaml:version > "4.08.0"} "--absolute-dylibs" {os = "macos"} ]
+  ["sh" "./configure" "--absolute-dylibs" {os = "macos"} ]
   [make]
 ]
 install: [

--- a/opam/opam
+++ b/opam/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/nberth/mlgmpidl/issues"
 homepage: "https://www.inrialpes.fr/pop-art/people/bjeannet/mlxxxidl-forge/mlgmpidl/"
 license: "LGPL-2.1 with static linking exception"
 build: [
-  ["sh" "./configure" "--absolute-dylibs" {os = "macos"} ]
+  ["sh" "./configure" "-disable-profiling" {ocaml:version > "4.08.0"} "--absolute-dylibs" {os = "macos"} ]
   [make]
 ]
 install: [


### PR DESCRIPTION
I'm trying to run `opam pin mlgmpidl git+https://github.com/nberth/mlgmpidl`, but it fails with the following error message.

```
# Profiling with "gprof" (option `-p') is only supported up to OCaml 4.08.0
# make: *** [mpz.p.cmx] Error 2
# rm mpq_caml.o mpz_caml.o mpf_caml.o gmp_random_caml.o mpfr_caml.o gmp_caml.o
```

Can we add the `-disable-profiling` flag with filter `{ocaml:version > "4.08.0"}` to the build step?