### PR TITLE
Remove stray [ in the LaTeX manual

### DIFF
--- a/mlgmpidl.tex
+++ b/mlgmpidl.tex
@@ -1,4 +1,4 @@
-\documentclass[[twoside,10pt,a4paper]{report}
+\documentclass[twoside,10pt,a4paper]{report}
 \usepackage[latin1]{inputenc}
 \usepackage[T1]{fontenc}
 \usepackage{textcomp}


### PR DESCRIPTION
Fixes a LaTeX warning about unknown option "[twoside".